### PR TITLE
Update requirements.pip

### DIFF
--- a/requirements.pip
+++ b/requirements.pip
@@ -1,5 +1,5 @@
 torch
-sklearn
+scikit-learn
 numpy
 matplotlib
 pandas


### PR DESCRIPTION
The 'sklearn' PyPI package is deprecated, use 'scikit-learn' rather than 'sklearn' for pip commands.